### PR TITLE
docs: update link to VS Code extension directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Here are some of them with syntax highlighting from the [LO VS Code extension][l
 
 > This option also works in vscode.dev
 
-- Install the [LO VS Code extension][lo-extension]
+- Install the [LO VS Code extension][vscode-ext]
 - To create a new project: Open empty folder, execute Command Palette: `LO: Initialize project in current workspace`
 - To run currently open file: execute Command Palette: `LO: Run current file`, or press ▶️ button in the top toolbar
 - Compiling files:


### PR DESCRIPTION
Hey @glebbash 👋  I hope you don't mind a couple unsolicited PRs. I was just playing around with this project after seeing it on HN and hit a couple speed bumps getting set up. Feel free to pass along any feedback if these suggestions aren't a good fit.

## Problem

The README link to the VS Code extension leads to a 404 when followed on Github.

## Solution

Update the link to point to the current extension directory.