### PR TITLE
build: specify nightly toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are some of them with syntax highlighting from the [LO VS Code extension][l
 
 - Requirements:
   - Install [rustup](https://www.rust-lang.org/tools/install)
-  - Switch to nightly: `rustup toolchain install nightly`
+  - Install nightly: `rustup toolchain install nightly`
   - Add WASM target: `rustup +nightly target add wasm32-unknown-unknown`
   - You can also find configs for GitHub Codespaces and GitPod in this repo
 - Run `./build.sh`

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Here are some of them with syntax highlighting from the [LO VS Code extension][l
 - Requirements:
   - Install [rustup](https://www.rust-lang.org/tools/install)
   - Switch to nightly: `rustup toolchain install nightly`
-  - Add WASM target: `rustup target add  wasm32-unknown-unknown`
+  - Add WASM target: `rustup +nightly target add wasm32-unknown-unknown`
   - You can also find configs for GitHub Codespaces and GitPod in this repo
 - Run `./build.sh`
 

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-cargo rustc --release --target=wasm32-unknown-unknown \
+cargo +nightly rustc --release --target=wasm32-unknown-unknown \
     -- -C target-feature=+multivalue
 
 cp target/wasm32-unknown-unknown/release/lo.wasm .


### PR DESCRIPTION
## Problem

The build instructions don't work when the default rust toolchain is set to `stable` (i.e., for a fresh rust install) and the instructions are followed verbatim.

**Steps to reproduce**

Reset your local environment to one somewhat reflecting a fresh rust install - i.e., the default toolchain is `stable` and the `wasm32` target is not yet installed - and then execute the build instructions as written.

1. Uninstall `wasm32` from the nightly toolchain: `rustup +nightly target remove wasm32-unknown-unknown`
2. Set the default toolchain to `stable`: `rustup default stable`
3. Remove cached builds: `rm -rf target`
4. Follow the README steps for building the initial compiler.
   > - Switch to nightly: `rustup toolchain install nightly`
   > - Add WASM target: `rustup target add  wasm32-unknown-unknown`
   > ...
   > - Run `./build.sh`

**Expected result**
The build succeeds.

**Actual result**
Build fails with an error because the stable toolchain (current default) is used.

```
error[E0554]: `#![feature]` may not be used on the stable release channel
 --> src/lib.rs:2:1
  |
2 | #![feature(alloc_error_handler)]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0554`.
error: could not compile `lo` (lib) due to 1 previous error
```

## Solution

Update the build script to specify `+nightly` so that it uses the correct toolchain, regardless of which toolchain is currently set as the default.

Also, the README is updated to specify the nightly toolchain when adding the `wasm32` target. The current instruction has the user install the `wasm32` target to whichever toolchain is the current default, not necessarily `nightly`.