### PR TITLE
Add a toolchain file to specify rust channel

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+targets = [ "wasm32-unknown-unknown" ]


### PR DESCRIPTION
## Problem

The [Rust Analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) extension for VS Code is presenting errors where nightly features are used.

![image](https://github.com/glebbash/LO/assets/1534986/ac2c3d82-0056-486b-8830-8e76fef186d5)

## Solution

Add a [toolchain file](https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file) specifying that this project should use `nightly`.

Note: this might make my other PR redundant (https://github.com/glebbash/LO/pull/11), though I haven't tested it yet.